### PR TITLE
Feat: useDocumentTitle

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ yarn add @jimengio/jimo-hooks
 - [useDebouncedClick](#useDebouncedClick)
 - [useDeepCompareCache](#useDeepCompareCache)
 - [useDeepEffect](#useDeepEffect)
+- [useDocumentTitle](#useDocumentTitle)
 - [useLoadImg](#useLoadImg)
 
 ### useAsyncClick
@@ -181,6 +182,25 @@ const Demo = ({ value: Object }) => {
   }, [value]);
 
   // ...
+};
+```
+
+### useDocumentTitle
+
+Setting page title
+
+| option  | type             | default | explain                  |
+| ------- | ---------------- | ------- | ------------------------ |
+| title   | string, function |         | title or title formatter |
+| restore | boolean          | false   | restore on unmount       |
+
+```tsx
+import { useDocumentTitle } from "@jimengio/jimo-hooks";
+
+const Demo = () => {
+  useDocumentTitle("page title");
+
+  return <div />;
 };
 ```
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,6 +4,7 @@ import useDebouncedCallback from "./useDebouncedCallback";
 import useDebouncedClick from "./useDebouncedClick";
 import useDeepCompareCache from "./useDeepCompareCache";
 import useDeepEffect from "./useDeepEffect";
+import useDocumentTitle from "./useDocumentTitle";
 import useLoadImg from "./useLoadImg";
 
 export {
@@ -13,5 +14,6 @@ export {
   useDebouncedClick,
   useDeepCompareCache,
   useDeepEffect,
+  useDocumentTitle,
   useLoadImg,
 };

--- a/src/useDocumentTitle.ts
+++ b/src/useDocumentTitle.ts
@@ -1,0 +1,30 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * useDocumentTitle
+ *
+ * @param title
+ * @param restore Restore on unmount
+ */
+export default function useDocumentTitle(
+  title: string | ((title: string) => string),
+  restore?: boolean
+) {
+  const prevTitleRef = useRef<string>(document.title);
+
+  useEffect(() => {
+    document.title =
+      typeof title === "function" ? title(document.title) : title;
+  }, [title]);
+
+  useEffect(() => {
+    if (restore) {
+      const prevTitle = prevTitleRef.current;
+      return () => {
+        document.title = prevTitle;
+      };
+    } else {
+      return;
+    }
+  }, [restore]);
+}

--- a/tests/useDocumentTitle.test.ts
+++ b/tests/useDocumentTitle.test.ts
@@ -1,0 +1,63 @@
+import { renderHook } from "@testing-library/react-hooks";
+
+import useDocumentTitle from "../src/useDocumentTitle";
+
+const Title1 = "title 1";
+const Title2 = "title 2";
+
+describe("useDocumentTitle", () => {
+  it("Init", () => {
+    const { rerender } = renderHook(
+      ({ title }) => {
+        useDocumentTitle(title);
+      },
+      {
+        initialProps: { title: Title1 },
+      }
+    );
+
+    rerender();
+    expect(document.title).toEqual(Title1);
+    rerender({ title: Title2 });
+    expect(document.title).toEqual(Title2);
+  });
+
+  it("Unmount", () => {
+    const { rerender: rerender1 } = renderHook(
+      ({ title }) => {
+        useDocumentTitle(title);
+      },
+      {
+        initialProps: { title: Title1 },
+      }
+    );
+    rerender1();
+    expect(document.title).toEqual(Title1);
+
+    const { rerender: rerender2, unmount } = renderHook(
+      (props: { title: string; restore?: boolean }) => {
+        useDocumentTitle(props.title, props.restore);
+      },
+      {
+        initialProps: { title: Title2, restore: true },
+      }
+    );
+    rerender2();
+    expect(document.title).toEqual(Title2);
+    unmount();
+    expect(document.title).toEqual(Title1);
+  });
+
+  it("Formatter", () => {
+    const { rerender } = renderHook(
+      (props: { title: string | ((title: string) => string) }) => {
+        useDocumentTitle(props.title);
+      }
+    );
+
+    rerender({ title: Title1 });
+    expect(document.title).toEqual(Title1);
+    rerender({ title: (t: string) => `${t} ${Title2}` });
+    expect(document.title).toEqual(`${Title1} ${Title2}`);
+  });
+});


### PR DESCRIPTION
Setting page title  `document.title`

| option  | type             | default | explain                  |
| ------- | ---------------- | ------- | ------------------------ |
| title   | string, function |         | title or title formatter |
| restore | boolean          | false   | restore on unmount       |
