### PR TITLE
Feat: Move out useThrottle / useThrottleFn 

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,6 +5,7 @@
 
 /dist
 /lib
+/esm
 /tests
 /example
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 /dist
 /lib
+/esm
 
 npm-debug.log*
 yarn-debug.log*

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Click event with `loading` and `debounce`
 | option    | type     | default | explain                             |
 | --------- | -------- | ------- | ----------------------------------- |
 | asyncFunc | function |         | async function                      |
-| delay     | number   | 300     | useDebouncedCallbackArgs["delay"]   |
+| delay     | number   | 0       | useDebouncedCallbackArgs["delay"]   |
 | options   | Object   |         | useDebouncedCallbackArgs["options"] |
 
 | return                  | type     | default | explain                                                |

--- a/README.md
+++ b/README.md
@@ -237,16 +237,39 @@ const Demo = () => {
 
 ### useThrottle
 
-throttle value
+throttled value
 
-| option | type   | default | explain |
-| ------ | ------ | ------- | ------- |
-| value  | any    |         |         |
-| wait   | number | 300     |         |
+<table>
+  <tr>
+    <th colspan="2">option</th>
+    <th>type</th>
+    <th>default</th>
+    <th>explain</th>
+  </tr>
+  <tr>
+    <td colspan="2">value</td>
+    <td>any</td>
+    <td>-</td>
+    <td>The value to throttle.</td>
+  </tr>
+  <tr>
+    <td colspan="2">wait</td>
+    <td>number</td>
+    <td>0</td>
+    <td>The number of milliseconds to throttle invocations to.</td>
+  </tr>
+  <tr>
+    <td rowspan="1">options</td>
+    <td>leading</td>
+    <td>boolean</td>
+    <td>-</td>
+    <td>Specify invoking on the leading edge of the timeout.</td>
+  </tr>
+</table>
 
-| return | type | default       | explain |
-| ------ | ---- | ------------- | ------- |
-| value  | any  | options.value |         |
+| return | type | explain                          |
+| ------ | ---- | -------------------------------- |
+| value  | any  | Returns the new throttled value. |
 
 ```tsx
 import { useThrottle } from "@jimengio/jimo-hooks";
@@ -260,17 +283,41 @@ const Demo = ({ value }) => {
 
 ### useThrottleFn
 
-throttle function
+throttled function
 
-| option | type     | default | explain |
-| ------ | -------- | ------- | ------- |
-| fn     | function |         |         |
-| wait   | number   | 300     |         |
+<table>
+  <tr>
+    <th colspan="2">option</th>
+    <th>type</th>
+    <th>default</th>
+    <th>explain</th>
+  </tr>
+  <tr>
+    <td colspan="2">fn</td>
+    <td>function</td>
+    <td>-</td>
+    <td>The function to throttle.</td>
+  </tr>
+  <tr>
+    <td colspan="2">wait</td>
+    <td>number</td>
+    <td>0</td>
+    <td>The number of milliseconds to throttle invocations to.</td>
+  </tr>
+  <tr>
+    <td rowspan="1">options</td>
+    <td>leading</td>
+    <td>boolean</td>
+    <td>-</td>
+    <td>Specify invoking on the leading edge of the timeout.</td>
+  </tr>
+</table>
 
-| return   | type     | default | explain |
-| -------- | -------- | ------- | ------- |
-| callback | function |         |         |
-| cancel   | function |         |         |
+| return      | type     | explain                         |
+| ----------- | -------- | ------------------------------- |
+| callback    | function | The new throttled function.     |
+| cancel      | function | The clear timer function.       |
+| callPending | function | The callback manually function. |
 
 ```tsx
 import { useThrottleFn } from "@jimengio/jimo-hooks";
@@ -329,6 +376,7 @@ const Demo = () => {
 
 - [lodash.isequal](https://github.com/lodash/lodash)
 - [use-debounce](https://github.com/xnimorz/use-debounce)
+- [@react-cmpt/use-throttle](https://github.com/react-cmpt/use-throttle)
 
 ## Dev
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "author": "wangcch <wangcch.cc@gmail.com>",
   "license": "MIT",
   "dependencies": {
+    "@react-cmpt/use-throttle": "^0.2.0",
     "lodash.isequal": "^4.5.0",
     "use-debounce": "^3.4.2"
   },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "license": "MIT",
   "dependencies": {
     "lodash.isequal": "^4.5.0",
-    "use-debounce": "^3.4.1"
+    "use-debounce": "^3.4.2"
   },
   "peerDependencies": {
     "react": "^16.8.0",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,12 @@
   "description": "Some react hooks",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
+  "module": "esm/index.js",
+  "sideEffects": false,
   "scripts": {
-    "build": "rm -rf ./lib/ && tsc -d --project tsconfig.json --outDir ./lib/",
+    "build": "rm -rf ./lib/* ./esm/* && yarn build:cjs && yarn build:es",
+    "build:cjs": "tsc",
+    "build:es": "tsc -p ./tsconfig.es.json",
     "test": "jest -c jest.json",
     "lint": "eslint 'src/**/*.{ts,tsx}'",
     "prettier": "prettier --write './src/**/*.{ts,tsx}' --config ./.prettierrc",

--- a/src/useDebouncedClick.ts
+++ b/src/useDebouncedClick.ts
@@ -13,12 +13,12 @@ export type ReturnResult<Args extends any[] = any[]> = {
  * useDebouncedClick
  *
  * @param asyncFunc
- * @param wait number @default 300
+ * @param wait number @default 0
  * @param options maxWait, leading, trailing
  */
 export default function useDebouncedClick<R = any, Args extends any[] = any[]>(
   asyncFunc: (...args: Args) => Promise<R>,
-  wait = 300,
+  wait = 0,
   options?: { maxWait?: number; leading?: boolean; trailing?: boolean }
 ): ReturnResult<Args> {
   const { callback, loading, error } = useAsyncClick<R, Args>(asyncFunc);

--- a/src/useThrottle.ts
+++ b/src/useThrottle.ts
@@ -1,23 +1,10 @@
-import { useState } from "react";
-import useUpdateEffect from "./useUpdateEffect";
-import useThrottleFn from "./useThrottleFn";
+import { useThrottle } from "@react-cmpt/use-throttle";
 
 /**
  * useThrottle
  *
  * @param value
- * @param wait number @default 300
+ * @param wait number @default 0
+ * @param options object
  */
-export default function useThrottle<T>(value: T, wait = 300): T {
-  const [state, setState] = useState<T>(value);
-
-  const { callback } = useThrottleFn((v: T) => {
-    setState(v);
-  }, wait);
-
-  useUpdateEffect(() => {
-    callback(value);
-  }, [value]);
-
-  return state;
-}
+export default useThrottle;

--- a/src/useThrottleFn.ts
+++ b/src/useThrottleFn.ts
@@ -1,45 +1,16 @@
-import { useCallback, useRef } from "react";
-import useUnmount from "./useUnmount";
+import {
+  useThrottleFn,
+  ThrottleOptions,
+  ThrottleReturnResult,
+} from "@react-cmpt/use-throttle";
+
+export { useThrottleFn, ThrottleOptions, ThrottleReturnResult };
 
 /**
  * useThrottleFn
  *
  * @param fn function
- * @param wait number @default 300
+ * @param wait number @default 0
+ * @param options object
  */
-export default function useThrottleFn<T extends any[]>(
-  fn: (...args: T) => any,
-  wait = 300
-): { callback: (...args: T) => void; cancel: () => void } {
-  const timer = useRef<ReturnType<typeof setTimeout>>();
-  const fnRef = useRef(fn);
-  fnRef.current = fn;
-  const currentArgs = useRef<any>();
-
-  const cancel = useCallback(() => {
-    if (timer.current) {
-      clearTimeout(timer.current);
-    }
-    timer.current = undefined;
-  }, []);
-
-  const callback = useCallback(
-    (...args: T) => {
-      currentArgs.current = args;
-      if (!timer.current) {
-        timer.current = setTimeout(() => {
-          fnRef.current(...currentArgs.current);
-          timer.current = undefined;
-        }, wait);
-      }
-    },
-    [wait]
-  );
-
-  useUnmount(() => cancel);
-
-  return {
-    callback,
-    cancel,
-  };
-}
+export default useThrottleFn;

--- a/tsconfig.es.json
+++ b/tsconfig.es.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "outDir": "./esm"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,11 +3,13 @@
     "allowSyntheticDefaultImports": true,
     "moduleResolution": "node",
     "target": "es5",
-    "module": "esnext",
+    "module": "commonjs",
     "strict": true,
     "jsx": "react",
     "lib": ["dom", "esnext"],
-    "sourceMap": true
+    "allowJs": true,
+    "outDir": "./lib",
+    "declaration": true
   },
   "include": ["src/**/*"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6286,10 +6286,10 @@ urix@^0.1.0:
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
 
-use-debounce@^3.4.1:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/use-debounce/-/use-debounce-3.4.1.tgz#361a20e583c1bd4a44f8b29a26793a52a0b84d2c"
-  integrity sha512-KHZPsL+cZvOt/ZAsHTcoAK65ImXU0iG9FDeofuj9uJTdUULF6Gjws8HpK+JlIjZpZ7LTqPHZtEknc+Im4cB3AA==
+use-debounce@^3.4.2:
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/use-debounce/-/use-debounce-3.4.2.tgz#f4333cca59504244b916159600427bf977ec4c46"
+  integrity sha512-rW44wZaFPh3XiwUzGBA0JRuklpbfKO/szU/5CYD2Q/erLmCem63lJ650p3a+NJE6S+g0rulKtBOfa/3rw/GN+Q==
 
 use@^3.1.0:
   version "3.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -563,6 +563,11 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
+"@react-cmpt/use-throttle@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@react-cmpt/use-throttle/-/use-throttle-0.2.0.tgz#5c9598ca92f30863f4c01dc1cd5191edf7cac79b"
+  integrity sha512-MljUaErh+IpGMuy9pZuoeo7sM7/oVNO1SLOerAt1vCRYAvmiJFlaTQ3uPM9fMhUx2lK/8XwCs3FF+ZL3+Yz+4A==
+
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz#ecdf48d532c58ea477acfcab80348424f8d0662f"


### PR DESCRIPTION
1. build: commonjs (`./lib`) and es module (`./esm`);
2. chore(deps): `use-debounce` 3.4.1 -> 3.4.2;
3. feat: move out useThrottle / useThrottleFn
    depend on [@react-cmpt/use-throttle](https://github.com/react-cmpt/use-throttle)
4. feat: remove the default wait value (300 -> 0)